### PR TITLE
Decode 0x06 as undef as per spec. Leave 0x0A as encoding?

### DIFF
--- a/lib/BSON.pm
+++ b/lib/BSON.pm
@@ -235,6 +235,11 @@ sub d_hash {
             $bson = substr( $bson, $len, length($bson) - $len );
         }
 
+        # Undef
+        elsif ( $type == 0x06 ) {
+            $value = undef;
+        }
+
         # ObjectId
         elsif ( $type == 0x07 ) {
             ( my $oid, $bson ) = unpack( 'a12a*', $bson );


### PR DESCRIPTION
Right now this module encodes undef as 0x0A (null value in spec). My patch doesn't change that; without further work the module will lack a way to generate that BSON (but it can at least decode it).
